### PR TITLE
Configurably allow access to unexported struct fields

### DIFF
--- a/chan.go
+++ b/chan.go
@@ -8,8 +8,8 @@ import (
 
 func checkChan(L *lua.LState, idx int) reflect.Value {
 	ud := L.CheckUserData(idx)
-	ref := reflect.ValueOf(ud.Value)
-	if ref.Kind() != reflect.Chan {
+	ref, ok := ud.Value.(reflect.Value)
+	if !ok || ref.Kind() != reflect.Chan {
 		L.ArgError(idx, "expecting chan")
 	}
 	return ref

--- a/example_test.go
+++ b/example_test.go
@@ -172,7 +172,7 @@ func Example__3() {
 		panic(err)
 	}
 
-	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.(map[string]*Person)
+	everyone := L.GetGlobal("everyone").(*lua.LUserData).Value.Interface().(map[string]*Person)
 	fmt.Println(len(everyone))
 	// Output:
 	// John
@@ -704,7 +704,7 @@ func Example__23() {
 	if err := L.DoString(code); err != nil {
 		panic(err)
 	}
-	b := L.GetGlobal("b").(*lua.LUserData).Value.(complex128)
+	b := L.GetGlobal("b").(*lua.LUserData).Value.Interface().(complex128)
 	fmt.Println(a == b)
 	// Output:
 	// true

--- a/map.go
+++ b/map.go
@@ -8,8 +8,8 @@ import (
 
 func checkMap(L *lua.LState, idx int) reflect.Value {
 	ud := L.CheckUserData(idx)
-	ref := reflect.ValueOf(ud.Value)
-	if ref.Kind() != reflect.Map {
+	ref, ok := ud.Value.(reflect.Value)
+	if !ok || ref.Kind() != reflect.Map {
 		L.ArgError(idx, "expecting map")
 	}
 	return ref

--- a/slice.go
+++ b/slice.go
@@ -8,8 +8,8 @@ import (
 
 func checkSlice(L *lua.LState, idx int) reflect.Value {
 	ud := L.CheckUserData(idx)
-	ref := reflect.ValueOf(ud.Value)
-	if ref.Kind() != reflect.Slice {
+	ref, ok := ud.Value.(reflect.Value)
+	if !ok || ref.Kind() != reflect.Slice {
 		L.ArgError(idx, "expecting slice")
 	}
 	return ref

--- a/struct.go
+++ b/struct.go
@@ -8,8 +8,8 @@ import (
 
 func checkStruct(L *lua.LState, idx int) reflect.Value {
 	ud := L.CheckUserData(idx)
-	ref := reflect.ValueOf(ud.Value)
-	if ref.Kind() != reflect.Struct {
+	ref, ok := ud.Value.(reflect.Value)
+	if !ok || ref.Kind() != reflect.Struct {
 		L.ArgError(idx, "expecting struct")
 	}
 	return ref
@@ -31,10 +31,7 @@ func structIndex(L *lua.LState) int {
 
 	// Check for field
 	if field := ref.FieldByName(exKey); field.IsValid() {
-		if !field.CanInterface() {
-			L.RaiseError("cannot interface field " + exKey)
-		}
-		L.Push(New(L, field.Interface()))
+		L.Push(NewReflected(L, field))
 		return 1
 	}
 

--- a/util.go
+++ b/util.go
@@ -5,7 +5,21 @@ import (
 	"unicode/utf8"
 )
 
+var (
+	// If set to true (in an init function or something), then globally,
+	// all reflected structs will allow access to unexported members through
+	// luar. You really shouldn't set this to true unless you know for sure
+	// all usages of luar will be for debugging purposes.
+	// TODO: This is so gross. We should move this setting to a registered
+	// object specific place, instead of being global and terrible. Should
+	// probably be a different type of New method or something.
+	AllowUnexportedAccesses bool = false
+)
+
 func getExportedName(name string) string {
+	if AllowUnexportedAccesses {
+		return name
+	}
 	buf := []byte(name)
 	first, n := utf8.DecodeRune(buf)
 	if n == 0 {


### PR DESCRIPTION
Why would I make something so terrible possible? Because this makes luar
super useful for a live-debugging technique of enabled processes, similar
to twisted's manhole feature

https://twistedmatrix.com/documents/current/api/twisted.conch.manhole.html