### PR TITLE
Functions attached on typed slices

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -33,6 +33,13 @@ func sliceIndex(L *lua.LState) int {
 		case "append":
 			L.Push(L.NewFunction(sliceAppend))
 		default:
+			exKey := getExportedName(string(converted))
+			if exKey != "" {
+				if method, ok := ref.Type().MethodByName(exKey); ok {
+					L.Push(New(L, method.Func.Interface()))
+					return 1
+				}
+			}
 			return 0
 		}
 	default:


### PR DESCRIPTION

I found that the method attached in aliased slice type cannot be called. Following snippet is my failing case.

```go
package main

import (
	"github.com/layeh/gopher-luar"
	"github.com/yuin/gopher-lua"
)

type Item struct {
	Id int32
}
type Items []*Item

func (a Items) First() *Item {
	if len(a) > 0 {
		return a[0]
	} else {
		return nil
	}
}

func (a *Items) Append(id int32) {
	*a = append(*a, &Item{id})
}

type Member struct {
	Inventory Items
}

func main() {
	member := Member{}
	member.Inventory.Append(1345)

	L := lua.NewState()
	L.SetGlobal("member", luar.New(L, member))
	defer L.Close()
	if err := L.DoString(`print(member.Inventory:First().Id)`); err != nil {
		panic(err)
	}
}
```

method First() cannot be found, causes "attempt to call a non-function object" error.
This patch fixes it by evaluating attached method at sliceIndex().