### PR TITLE
Fix bug in interface reflection for map key type

### DIFF
--- a/luar.go
+++ b/luar.go
@@ -192,7 +192,7 @@ func lValueToReflect(L *lua.LState, v lua.LValue, hint reflect.Type, tryConvertP
 			return s
 
 		case hint.Kind() == reflect.Map:
-			keyType := hint.Elem()
+			keyType := hint.Key()
 			elemType := hint.Elem()
 			s := reflect.MakeMap(hint)
 

--- a/luar.go
+++ b/luar.go
@@ -180,10 +180,10 @@ func lValueToReflect(L *lua.LState, v lua.LValue, hint reflect.Type, tryConvertP
 		switch {
 		case hint.Kind() == reflect.Slice:
 			elemType := hint.Elem()
-			len := converted.Len()
-			s := reflect.MakeSlice(hint, len, len)
+			length := converted.Len()
+			s := reflect.MakeSlice(hint, length, length)
 
-			for i := 0; i < len; i++ {
+			for i := 0; i < length; i++ {
 				value := converted.RawGetInt(i + 1)
 				elemValue := lValueToReflect(L, value, elemType, nil)
 				s.Index(i).Set(elemValue)


### PR DESCRIPTION
Pretty clear bug. This was manifesting with a function getting passed a `map[interface{}]interface{}` instead of the expected `map[string]interface{}`. All tests pass after the change.

Also cleans up naming conflict with the `len` builtin.