### PR TITLE
Add in options to configure how method and field names get converted to Lua keys

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -48,8 +48,12 @@ func addMethods(L *lua.LState, vtype reflect.Type, tbl *lua.LTable, ptrReceiver 
 			continue
 		}
 		fn := funcWrapper(L, method.Func, ptrReceiver)
-		tbl.RawSetString(method.Name, fn)
-		tbl.RawSetString(getUnexportedName(method.Name), fn)
+		if options.MethodNames == ExportedNameStyle || options.MethodNames == ExportedUnexportNameStyle {
+			tbl.RawSetString(method.Name, fn)
+		}
+		if options.MethodNames == UnexportedNameStyle || options.MethodNames == ExportedUnexportNameStyle {
+			tbl.RawSetString(getUnexportedName(method.Name), fn)
+		}
 	}
 }
 
@@ -84,9 +88,12 @@ func addFields(L *lua.LState, vtype reflect.Type, tbl *lua.LTable) {
 					tag,
 				}
 			} else {
-				names = []string{
-					field.Name,
-					getUnexportedName(field.Name),
+				if options.FieldNames == ExportedNameStyle || options.FieldNames == ExportedUnexportNameStyle {
+					names = append(names, field.Name)
+				}
+
+				if options.FieldNames == UnexportedNameStyle || options.FieldNames == ExportedUnexportNameStyle {
+					names = append(names, getUnexportedName(field.Name))
 				}
 			}
 			for _, key := range names {

--- a/options.go
+++ b/options.go
@@ -1,0 +1,32 @@
+package luar // import "layeh.com/gopher-luar"
+
+// NameOptions is a type to define the valid settings for how to handle names.
+type NameOptions int8
+
+// Options defines the configurable value for the luar library.
+type Options struct {
+	MethodNames, FieldNames NameOptions
+}
+
+// Specifies the method to use in creating names for fields and methods for
+// Go types in Lua.
+const (
+	ExportedUnexportNameStyle NameOptions = iota
+	ExportedNameStyle
+	UnexportedNameStyle
+)
+
+// DefaultOptions for the library
+var DefaultOptions = Options{
+	MethodNames: ExportedUnexportNameStyle,
+	FieldNames:  ExportedUnexportNameStyle,
+}
+
+// stores current configuration
+var options = DefaultOptions
+
+// Configure lets the user pass in a customer configuration to adjust the
+// behavior of the library.
+func Configure(opts Options) {
+	options = opts
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,110 @@
+package luar
+
+import (
+	"testing"
+
+	"github.com/yuin/gopher-lua"
+)
+
+// NOTE: Not testing default options, that should be tested by the remaining
+//       tests not depending on specific configuration values.
+
+func Test_FieldNames_UnexportedNameStyle(t *testing.T) {
+	L := lua.NewState()
+
+	tim := StructTestPerson{
+		Name: "Tim",
+		Age:  30,
+	}
+
+	Configure(Options{
+		FieldNames: UnexportedNameStyle,
+	})
+
+	L.SetGlobal("user", New(L, tim))
+
+	testReturn(t, L, `return user.Name`, "nil")
+	testReturn(t, L, `return user.name`, "Tim")
+	testReturn(t, L, `return user.Age`, "nil")
+	testReturn(t, L, `return user.age`, "30")
+
+	// method names should be unaffected
+	testReturn(t, L, `return user:Hello()`, "Hello, Tim")
+	testReturn(t, L, `return user:hello()`, "Hello, Tim")
+
+	Configure(DefaultOptions)
+}
+
+func Test_FieldNames_ExportedNameStyle(t *testing.T) {
+	L := lua.NewState()
+
+	tim := StructTestPerson{
+		Name: "Tim",
+		Age:  30,
+	}
+
+	Configure(Options{
+		FieldNames: ExportedNameStyle,
+	})
+
+	L.SetGlobal("user", New(L, tim))
+
+	testReturn(t, L, `return user.Name`, "Tim")
+	testReturn(t, L, `return user.name`, "nil")
+	testReturn(t, L, `return user.Age`, "30")
+	testReturn(t, L, `return user.age`, "nil")
+
+	// method names should be unaffected
+	testReturn(t, L, `return user:Hello()`, "Hello, Tim")
+	testReturn(t, L, `return user:hello()`, "Hello, Tim")
+
+	Configure(DefaultOptions)
+}
+
+func Test_MethodNames_UnexportedNameStyle(t *testing.T) {
+	L := lua.NewState()
+
+	tim := StructTestPerson{
+		Name: "Tim",
+		Age:  30,
+	}
+
+	Configure(Options{
+		MethodNames: UnexportedNameStyle,
+	})
+
+	L.SetGlobal("user", New(L, tim))
+
+	testReturn(t, L, `return user:hello()`, "Hello, Tim")
+	testReturn(t, L, `return user.Hello`, "nil")
+
+	// fiels should be unaffected
+	testReturn(t, L, `return user.Name`, "Tim")
+	testReturn(t, L, `return user.name`, "Tim")
+
+	Configure(DefaultOptions)
+}
+
+func Test_MethodNames_ExportedNameStyle(t *testing.T) {
+	L := lua.NewState()
+
+	tim := StructTestPerson{
+		Name: "Tim",
+		Age:  30,
+	}
+
+	Configure(Options{
+		MethodNames: ExportedNameStyle,
+	})
+
+	L.SetGlobal("user", New(L, tim))
+
+	testReturn(t, L, `return user:Hello()`, "Hello, Tim")
+	testReturn(t, L, `return user.hello`, "nil")
+
+	// fiels should be unaffected
+	testReturn(t, L, `return user.Name`, "Tim")
+	testReturn(t, L, `return user.name`, "Tim")
+
+	Configure(DefaultOptions)
+}


### PR DESCRIPTION
Added in an `Options` type and a `Configure` method to allow some slight configuration on how method and field names should get converted into Lua keys.

The current available options are `ExportedNameStyle`, `UnexportedNameStyle` and `ExportedUnexportedNameStyle` (the current behavior). This allows, via configuration, the ability to force all method/field names into one style or the other (or both in the case of default behavior).

It's simple to configure:

```go
luar.Configure(luar.Options{
        MethodNames: luar.ExportedNameStyle,
        FieldNames: luar.UnexportedNameStyle,
})
```

This PR will fix issue #23.