### PR TITLE
Raise more meaningful error for mistyped function inputs

### DIFF
--- a/func.go
+++ b/func.go
@@ -110,6 +110,9 @@ func funcRegular(L *lua.LState) int {
 			receiver = arg
 		} else {
 			arg = lValueToReflect(L, L.Get(i+1), hint, nil)
+			if !arg.IsValid() {
+				L.RaiseError("invalid type received for arg %d (expected %s)", i+1, hint)
+			}
 		}
 		args[i] = arg
 	}

--- a/func.go
+++ b/func.go
@@ -2,6 +2,7 @@ package luar // import "layeh.com/gopher-luar"
 
 import (
 	"reflect"
+	"runtime"
 
 	"github.com/yuin/gopher-lua"
 )
@@ -111,7 +112,8 @@ func funcRegular(L *lua.LState) int {
 		} else {
 			arg = lValueToReflect(L, L.Get(i+1), hint, nil)
 			if !arg.IsValid() {
-				L.RaiseError("invalid type received for arg %d (expected %s)", i+1, hint)
+				L.RaiseError("bad argument #%d to '%s' (expected %s)", i+1,
+					runtime.FuncForPC(ref.Pointer()).Name(), hint)
 			}
 		}
 		args[i] = arg

--- a/func_test.go
+++ b/func_test.go
@@ -218,18 +218,18 @@ func Test_func_luafunccall(t *testing.T) {
 	}
 }
 
+func testFnHelloPerson(p *StructTestPerson) string {
+	return "Hello, " + p.Name
+}
+
 func Test_func_invalidargtype(t *testing.T) {
 	L := lua.NewState()
 	defer L.Close()
 
 	family := &StructTestFamily{}
 
-	fn := func(p *StructTestPerson) string {
-		return "Hello, " + p.Name
-	}
-
 	L.SetGlobal("family", New(L, family))
-	L.SetGlobal("getHello", New(L, fn))
+	L.SetGlobal("getHello", New(L, testFnHelloPerson))
 
-	testError(t, L, `return getHello(family)`, "invalid type received for arg 1 (expected *luar.StructTestPerson)")
+	testError(t, L, `return getHello(family)`, "bad argument #1 to 'layeh.com/gopher-luar.testFnHelloPerson' (expected *luar.StructTestPerson)")
 }

--- a/func_test.go
+++ b/func_test.go
@@ -217,3 +217,19 @@ func Test_func_luafunccall(t *testing.T) {
 		t.Fatalf("expecting GetTop to return 0, got %d", L.GetTop())
 	}
 }
+
+func Test_func_invalidargtype(t *testing.T) {
+	L := lua.NewState()
+	defer L.Close()
+
+	family := &StructTestFamily{}
+
+	fn := func(p *StructTestPerson) string {
+		return "Hello, " + p.Name
+	}
+
+	L.SetGlobal("family", New(L, family))
+	L.SetGlobal("getHello", New(L, fn))
+
+	testError(t, L, `return getHello(family)`, "invalid type received for arg 1 (expected *luar.StructTestPerson)")
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -38,8 +38,8 @@ func (p *StructTestPerson) IncreaseAge() {
 }
 
 type StructTestFamily struct {
-	Mother StructTestPerson
-	Father StructTestPerson
+	Mother   StructTestPerson
+	Father   StructTestPerson
 	Children []StructTestPerson
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -37,6 +37,12 @@ func (p *StructTestPerson) IncreaseAge() {
 	p.Age++
 }
 
+type StructTestFamily struct {
+	Mother StructTestPerson
+	Father StructTestPerson
+	Children []StructTestPerson
+}
+
 func testReturn(t *testing.T, L *lua.LState, code string, values ...string) {
 	top := L.GetTop()
 	if err := L.DoString(code); err != nil {


### PR DESCRIPTION
Previous error was `reflect: Call using zero Value argument`.