### PR TITLE
add func CustomizeMetaTable

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,11 @@ func GetConfig(L *lua.LState) *Config {
 	return lConfig.Value.(*Config)
 }
 
+func CustomizeMetaTable(L *lua.LState, t reflect.Type, mt *lua.LTable) {
+	cfg := GetConfig(L)
+	cfg.regular[t] = mt
+}
+
 func defaultFieldNames(s reflect.Type, f reflect.StructField) []string {
 	const tagName = "luar"
 


### PR DESCRIPTION
add CustomizeMetaTable function to enable user define a customize metatable for specific type.

use case:

assume we have TypeA and TypeB
```go
type TypeA struct {
      B TypeB
}
type TypeB struct {
     some fields
}
```

then , we do `luar.New(&TypeA{})`,  but need TypeA.B has a metatable which is customized: something like customize __eq, __add, __sub ..., in this situation, we can call `CustomizeMetaTable` when the lua.LState is inited.

as a result, if we'v called `CustomizeMetaTable`, all TypeB will use the customized metatable