### PR TITLE
fix(lValueToReflectInner): throw type error when settign wrong type o…

### DIFF
--- a/luar.go
+++ b/luar.go
@@ -441,7 +441,7 @@ func lValueToReflectInner(L *lua.LState, v lua.LValue, hint reflect.Type, visite
 
 				lValue, err := lValueToReflectInner(L, value, field.Type, visited, nil)
 				if err != nil {
-					return reflect.Value{}, nil
+					return reflect.Value{}, err
 				}
 				t.FieldByIndex(field.Index).Set(lValue)
 			}

--- a/struct_test.go
+++ b/struct_test.go
@@ -3,7 +3,7 @@ package luar
 import (
 	"testing"
 
-	"github.com/yuin/gopher-lua"
+	lua "github.com/yuin/gopher-lua"
 )
 
 func Test_struct(t *testing.T) {
@@ -397,5 +397,55 @@ func Test_struct_unexport_anonymous_field(t *testing.T) {
 	fields := mt.RawGetString("fields").(*lua.LTable)
 	if field := fields.RawGetString("test_unexport_anonymous_child"); field != lua.LNil {
 		t.Errorf("expected test_unexport_anonymous_child to be nil, got %v", field)
+	}
+}
+
+type test_struct_convert_mismatch_type struct {
+	Str       string
+	Int       int
+	Bool      bool
+	Float32   float32
+	NestChild Test_nested_child1
+}
+
+func Test_struct_convert_mismatch_type(t *testing.T) {
+	{
+		// struct conversion in function argument
+		L := lua.NewState()
+		defer L.Close()
+		n := test_struct_convert_mismatch_type{}
+
+		fn := func(s *test_struct_convert_mismatch_type) {
+			n = *s
+		}
+		L.SetGlobal("fn", New(L, fn))
+		testError(t, L, `return fn({Str = 111})`, "bad argument")
+		testError(t, L, `return fn({Int = "foo"})`, "bad argument")
+		testError(t, L, `return fn({Float32 = "foo"})`, "bad argument")
+		testError(t, L, `return fn({Bool = "foo"})`, "bad argument")
+		testError(t, L, `return fn({NestChild = {Name = 1}})`, "bad argument")
+
+		if n.Float32 != 0 || n.Int != 0 ||
+			n.Bool != false || n.Str != "" || n.NestChild.Name != "" {
+			t.Errorf("field(s) are set when the type is mismatched: %+v", n)
+		}
+
+	}
+
+	{
+		// field assignment
+		L := lua.NewState()
+		defer L.Close()
+		n := &test_struct_convert_mismatch_type{}
+		L.SetGlobal("c", New(L, n))
+		testError(t, L, `c.Str = 1`, "bad argument")
+		testError(t, L, `c.Int = "foo"`, "bad argument")
+		testError(t, L, `c.Bool = "foo"`, "bad argument")
+		testError(t, L, `c.NestChild.Name = 1`, "bad argument")
+
+		if n.Float32 != 0 || n.Int != 0 ||
+			n.Bool != false || n.Str != "" || n.NestChild.Name != "" {
+			t.Errorf("field(s) are set when the type is mismatched: %+v", n)
+		}
 	}
 }


### PR DESCRIPTION
fix [issue](https://github.com/layeh/gopher-luar/issues/36).
Already tested with the example in the issue.
![image](https://github.com/layeh/gopher-luar/assets/45346013/6b42b5df-9f20-48f8-95e8-ab2908e789a6)

